### PR TITLE
DTFL-1: make working with nano a bit more plesant

### DIFF
--- a/nano/.nanorc
+++ b/nano/.nanorc
@@ -1,6 +1,10 @@
 set tabsize 2
 set linenumbers
-# set constantshow
+set fill 72
+set nowrap
+set softwrap
+set breaklonglines
+set constantshow
 set numbercolor green,black
 syntax "disabled" "."
 color white "."


### PR DESCRIPTION
I already have some configuration for nano in 'nano/.nanorc'. I have found that modifying the default wrap behavior, and setting a default wrap column number, gives a much better experience.

Also - turn on display of row and column information at all times.

Implements https://github.com/valera-rozuvan/dotfiles/issues/1.